### PR TITLE
Fix Padel typo in schema comment

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 /**
- * Схема базы данных Drizzle ORM для Padle World Club
+ * Схема базы данных Drizzle ORM для Padel World Club
  * Этот файл является точкой входа для всех схем таблиц.
  */
 


### PR DESCRIPTION
## Summary
- correct brand name typo in `src/db/schema.ts`

## Testing
- `bun run typecheck` *(fails: Cannot find type definition file for '@types/bun')*
- `bun run lint` *(fails: ESLint couldn't find a configuration file)*
- `bun test` *(fails: Cannot find module 'drizzle-orm/node-postgres')*